### PR TITLE
fix: locationId -> fetchLocation.locationId

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ exports.handler = async (event, context, callback) => {
     return slack.buildResponse(fetchLocation.errorMessage);
   }
 
-  return await zutool.fetch(locationId).then((response) => {
+  return await zutool.fetch(fetchLocation.locationId).then((response) => {
     // notice: zutoolのtomorrowの綴りが間違っているのでそちらに合わせています
     const day = parsedBody.isTomorrow ? response.tommorow : response.today;
     const dayStr = parsedBody.isTomorrow ? "明日" : "今日";


### PR DESCRIPTION
エラー修正
```
{"errorType":"TypeError","errorMessage":"Cannot read property 'filter' of undefined","trace":["TypeError: Cannot read property 'filter' of undefined","    at Object.exports.formatter (/var/task/zutool.js:36:6)","    at /var/task/index.js:33:10","    at processTicksAndRejections (internal/process/task_queues.js:97:5)","    at async Runtime.exports.handler (/var/task/index.js:28:10)"]}
```