### PR TITLE
`make zut` の追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ZIP=$(shell which zip)
 YARN=$(shell which yarn)
 
-.PHONY: zip install test
+.PHONY: zip install test zut
 
 install: 
 	$(YARN) install
@@ -11,3 +11,7 @@ zip:
 
 test: install
 	 $(YARN) test
+
+zut: install
+	 $(YARN) run zut ${ARG}
+

--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ $ make zip
 ```
 
 で圧縮したファイルをzipであげると動くよ
+
+### ローカルで/zutを動かす
+
+```
+$ make zut ARG="港区 --tomorrow"
+```

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ exports.handler = async (event, context, callback) => {
     return slack.buildResponse(fetchLocation.errorMessage);
   }
 
-  return await zutool.fetch(locationId).then((response) => {
+  return await zutool.fetch(fetchLocation.locationId).then((response) => {
     // notice: zutoolのtomorrowの綴りが間違っているのでそちらに合わせています
     const day = parsedBody.isTomorrow ? response.tommorow : response.today;
     const dayStr = parsedBody.isTomorrow ? "明日" : "今日";

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-const zutool = require("zutool");
-const location = require("location");
-const lambda = require("lambda");
-const slack = require("slack");
-const temperature = require("temperature");
-const help = require("help");
+const zutool = require("./zutool");
+const location = require("./location");
+const lambda = require("./lambda");
+const slack = require("./slack");
+const temperature = require("./temperature");
+const help = require("./help");
 
 exports.handler = async (event, context, callback) => {
   const parsedBody = parseBody(lambda.getBody(event));

--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ exports.handler = async (event, context, callback) => {
     return slack.buildResponse(help.message);
   }
 
-  const fetchLocation = parseBody.locationId
-    ? { locationId: parseBody.locationId, errorMessage: null }
-    : await location.fetchLocationId(parseBody.locationName);
+  const fetchLocation = parsedBody.locationId
+    ? { locationId: parsedBody.locationId, errorMessage: null }
+    : await location.fetchLocationId(parsedBody.locationName);
 
   if (fetchLocation.errorMessage) {
     return slack.buildResponse(fetchLocation.errorMessage);

--- a/location.js
+++ b/location.js
@@ -4,10 +4,10 @@ exports.fetchLocationId = async function (locationName) {
   const result = await search.byLocationName(locationName);
 
   if (result.length > 1) {
-    const result = result.map((r) => `${r.name}: ${r.city_code}`).join("\n");
+    const message = result.map((r) => `${r.name}: ${r.city_code}`).join("\n");
     return {
       errorMessage: `対象住所は複数該当します。天気表示は「市町村区名」のみ、または「city_code」で検索してください。
-${result}`,
+${message}`,
       locationId: null
     };
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "zut": "node ./run-zut.js"
   },
   "repository": {
     "type": "git",

--- a/run-zut.js
+++ b/run-zut.js
@@ -19,5 +19,5 @@ const { handler } = require("./index");
     },
   });
 
-  console.log(JSON.stringify(response));
+  console.dir(response, { depth: null });
 })();

--- a/run-zut.js
+++ b/run-zut.js
@@ -1,15 +1,23 @@
+/**
+ * ```shell
+ * $ node run-zut.js 港区 --tomorrow
+ * $ yarn run zut 港区 --tomorrow
+ * ```
+ */
 const { handler } = require("./index");
 
 (async () => {
+  const [, , ...textArray] = process.argv;
+
   const response = await handler({
     "body-json": {
       body: new URLSearchParams({
         token: "token",
         command: "/zut",
-        text: "港区",
+        text: textArray.join(" "),
       }).toString(),
     },
   });
 
-  console.log(JSON.stringify(response))
-})()
+  console.log(JSON.stringify(response));
+})();

--- a/run-zut.js
+++ b/run-zut.js
@@ -1,0 +1,15 @@
+const { handler } = require("./index");
+
+(async () => {
+  const response = await handler({
+    "body-json": {
+      body: new URLSearchParams({
+        token: "token",
+        command: "/zut",
+        text: "港区",
+      }).toString(),
+    },
+  });
+
+  console.log(JSON.stringify(response))
+})()


### PR DESCRIPTION
- `make zut 港区` でローカルで `/zut 港区` が実行できるようにした
- エラー修正

```shell
~/ghq/github.com/ShuzoN/zut · (feature/fix-errors±)
⟩ make zut ARG="港区 --tomorrow"
/usr/local/bin/yarn install
yarn install v1.22.4
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.28s.
/usr/local/bin/yarn run zut 港区 --tomorrow
yarn run v1.22.4
$ node ./run-zut.js 港区 --tomorrow
{
  response_type: 'in_channel',
  blocks: [
    {
      type: 'section',
      text: {
        type: 'mrkdwn',
        text: '対象住所は複数該当します。天気表示は「市町村区名」のみ、または「city_code」で検索してください。\n' +
          '東京都港区: 13103\n' +
          '愛知県名古屋市港区: 23111\n' +
          '大阪府大阪市港区: 27107'
      }
    }
  ]
}
✨  Done in 0.41s.
```