### PR TITLE
master merge時にdeployを実行する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Node.js CI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x]
+
+    steps:
+      - uses: actions/checkout@master
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@master
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: make install test
+      - uses: actions/aws/cli@master
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.ZUT_PUT_S3_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.ZUT_PUT_S3_AWS_SECRET_ACCESS_KEY }}
+        with:
+          args: make deploy

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,18 +4,16 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: make install test
-
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: make install test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 ZIP=$(shell which zip)
 YARN=$(shell which yarn)
+AWS=$(shell which aws)
 ARG=
 
 .PHONY: zip install test zut zut/ts build
@@ -8,7 +9,7 @@ install:
 	$(YARN) install
 
 zip:
-	$(ZIP) -r zut.zip .
+	$(ZIP) -r zut.zip ./dist/src
 
 test: install
 	$(YARN) test
@@ -21,3 +22,6 @@ zut/ts: install
 
 build: install
 	$(YARN) build
+
+deploy: build zip
+	$(AWS) s3 mv zut.zip s3://zut


### PR DESCRIPTION
https://github.com/ShuzoN/zut/issues/13

master merge 実行時にいちいちデプロイするのが面倒なので自動マージするようにする

戦略としてはs3にzipファイルをuploadしてlambdaから参照する形に

●リリースの影響範囲について

牡蠣や会社で利用しているlambdaは影響を受けない(production)。
stagingとして個人slackに連携しているlambdaを先にs3参照に変えてテストを行なっている。
stagingでの検証が成功したらproductionのlambdaもs3参照に切り替える。
stagingのs3からのzip参照が行えていることはすでに検証済み。
