### PR TITLE
fix(search): 場所名入力時に全角スペースを入れるとエラーになる不具合があったので、トリム処理を追加

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -7,7 +7,7 @@ export const byLocationName = async (
   if (locationName === "") {
     throw Error("検索文字列が指定されていません");
   }
-  const locationResponse = await zutool.search(locationName);
+  const locationResponse = await zutool.search(locationName.trim());
   const unescaped = unescape(locationResponse.result);
   return JSON.parse(unescaped);
 };

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -17,6 +17,14 @@ test("zutoolに対して場所検索を行えること", async () => {
   expect(actual).toEqual(expected);
 });
 
+test("zutoolに対して場所の文字列前後に全角スペースを入れても場所検索を行えること", async () => {
+  const actual = await search.byLocationName("　杉並　");
+  const expected = [
+    { city_code: "13115", name_kata: "ｽｷﾞﾅﾐｸ", name: "東京都杉並区" },
+  ];
+  expect(actual).toEqual(expected);
+});
+
 test("zutoolに対して空文字で検索した場合, 例外が返ること", () => {
   const promise = search.byLocationName("");
   expect(promise).rejects.toThrowError(


### PR DESCRIPTION
# 概要
場所名入力時に全角スペースを入れるとエラーになる不具合があったので、トリム処理を追加

# 再現方法
`/zut 和光市　`とzutに入力すると以下のエラーレスポンスが返ってくる

```
{"errorType":"SyntaxError","errorMessage":"Unexpected end of JSON input","trace":["SyntaxError: Unexpected end of JSON input","    at JSON.parse (<anonymous>)","    at IncomingMessage.<anonymous> (/var/task/zutool.js:41:51)","    at IncomingMessage.emit (events.js:314:20)","    at IncomingMessage.Readable.read (stream_readable.js:507:10)","    at flow (_stream_readable.js:1007:34)","    at resume (_stream_readable.js:988:3)","    at processTicksAndRejections (internal/process/task_queues.js:84:21)"]}
```



