### PR TITLE
zutoolから受け取ったjsonをフォーマットするテストコードの追加修正

### DIFF
--- a/test/zutool.test.ts
+++ b/test/zutool.test.ts
@@ -52,9 +52,8 @@ test("zutoolから受け取ったjsonを明日分についてフォーマット�
     "23時 :sunny: 9.7℃ 1013.9hPa :bomb:",
   ];
 
-  // notice: zutoolのtomorrowの綴りが間違っているのでそちらに合わせています
-  expect(zutool.formatter(zutoolJson.tommorow)).toStrictEqual(
-    expect.arrayContaining(formatted)
+  expect(formatted).toStrictEqual(
+      expect.arrayContaining(zutool.formatter(zutoolJson.tommorow))
   );
 });
 

--- a/test/zutool.test.ts
+++ b/test/zutool.test.ts
@@ -22,10 +22,7 @@ test("zutoolから受け取ったjsonを当日分についてフォーマット�
     "23時 :sunny: 12.8℃ 1023.6hPa :arrow_heading_down:",
   ];
 
-  expect(zutool.formatter(zutoolJson.today)).toEqual(
-    expect.arrayContaining(formatted)
-  );
-  expect(formatted).toEqual(
+  expect(formatted).toStrictEqual(
       expect.arrayContaining(zutool.formatter(zutoolJson.today))
   );
 });


### PR DESCRIPTION
実行結果

```
zut $ git branch --contains   
* fix_test
zut $ make zut/ts ARG="和光市"
/usr/local/bin/yarn install
yarn install v1.22.18
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.25s.
/usr/local/bin/yarn run zut/ts 和光市
yarn run v1.22.18
$ ts-node ./run-zut.ts 和光市
url: https://zutool.jp/api/getweatherstatus/11229
{
  response_type: 'in_channel',
  blocks: [
    {
      type: 'section',
      text: {
        type: 'mrkdwn',
        text: '今日 の天気\n' +
          '6時 :cloud: 11.3℃ 1015.3hPa :bomb:\n' +
          '7時 :cloud: 11.7℃ 1015hPa :bomb:\n' +
          '8時 :cloud: 11.6℃ 1014.9hPa :bomb:\n' +
          '9時 :cloud: 12.4℃ 1013.7hPa :bomb:\n' +
          '10時 :cloud: 12.7℃ 1012.5hPa :bomb:\n' +
          '11時 :cloud: 13.3℃ 1012hPa :bomb:\n' +
          '12時 :cloud: 13.5℃ 1010.9hPa :bomb:\n' +
          '13時 :umbrella: 14.3℃ 1009.9hPa :bomb:\n' +
          '14時 :umbrella: 14.5℃ 1008.8hPa :bomb:\n' +
          '15時 :umbrella: 13.3℃ 1007.5hPa :bomb:\n' +
          '16時 :umbrella: 12.1℃ 1006.8hPa :bomb:\n' +
          '17時 :umbrella: 11.2℃ 1006.4hPa :bomb:\n' +
          '18時 :umbrella: 10.8℃ 1006.3hPa :bomb:\n' +
          '19時 :umbrella: 10.7℃ 1006hPa :bomb:\n' +
          '20時 :umbrella: 10.7℃ 1006.3hPa :bomb:\n' +
          '21時 :umbrella: 10.9℃ 1006.4hPa :arrow_heading_down:\n' +
          '22時 :umbrella: 11℃ 1006hPa :arrow_heading_down:\n' +
          '23時 :cloud: 10.9℃ 1005.9hPa :arrow_heading_down:\n'
      }
    }
  ]
}
✨  Done in 1.67s.
```