### PR TITLE
DONE: json parseで失敗してた問題の対応

### DIFF
--- a/src/zutool.ts
+++ b/src/zutool.ts
@@ -18,7 +18,9 @@ export const fetch = async (
   return new Promise(function (resolve, reject) {
     https
       .get(url, (res) => {
-        res.on("data", (body) => resolve(JSON.parse(body)));
+        let body = '';
+        res.on('data', (chunk) => body += chunk);
+        res.on('end', () => resolve(JSON.parse(body)));
       })
       .on("error", (e: TODO) => {
         reject(Error(e));
@@ -34,7 +36,9 @@ export const search = (
   return new Promise(function (resolve, reject) {
     https
       .get(url, (res) => {
-        res.on("data", (body) => resolve(JSON.parse(body)));
+        let body = '';
+        res.on('data', (chunk) => body += chunk);
+        res.on('end', () => resolve(JSON.parse(body)));
       })
       .on("error", (e: TODO) => {
         reject(Error(e));


### PR DESCRIPTION
# 内容
* https.getではbodyが長い場合に部分的にしか取得できず、後続の`JSON.parse`でエラーが発生していた
* `on('end')` を使いstreamが閉じるまで待ち、取得しきったタイミングで`JSON.parse`するようにした

# 参考
https://zenn.dev/xxpiyomaruxx/articles/ab10b64fa3b17b#read%E3%81%AE%E3%81%97%E3%81%8F%E3%81%BF

# REF
<details>
<summary>起きてた事象</summary>


```
レスポンスボディが途切れてる
$ make zut/ts ARG='　北海道'
/usr/local/bin/yarn install
yarn install v1.21.1
warning ../../../../package.json: No license field
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 1.64s.
/usr/local/bin/yarn run zut/ts 　北海道
yarn run v1.21.1
warning ../../../../package.json: No license field
$ ts-node ./run-zut.ts 　北海道

/Users/zoe/src/github.com/ShuzoN/zut/src/zutool.ts:37
        res.on("data", (body) => resolve(JSON.parse(body)));
                                              ^
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at IncomingMessage.<anonymous> (/Users/zoe/src/github.com/ShuzoN/zut/src/zutool.ts:37:47)
    at IncomingMessage.emit (node:events:365:28)
    at IncomingMessage.emit (node:domain:470:12)
    at IncomingMessage.Readable.read (node:internal/streams/readable:525:10)
    at flow (node:internal/streams/readable:1009:34)
    at resume_ (node:internal/streams/readable:990:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
make: *** [Makefile:18: zut/ts] Error 1
```

</details>