### PR TITLE
 空白文字を含む場合でも地名,場所IDともに動くようにする

### DIFF
--- a/src/argBody.ts
+++ b/src/argBody.ts
@@ -11,11 +11,13 @@ export const parse = (body: LambdaBody): ParseBody => {
 
   // 引数がないもしくは'--'が入ってるときはhelp
   const isHelp = args[0] === "" || args[0].includes("--");
+  // 空白の除去
+  const trimed = args[0].trim();
   // locationIdは数値5桁(prefecturesId2桁 + placeId3桁)のみ指定されている場合
-  const gotLocationId = /^\d{5}$/.test(args[0]);
-  const locationId = gotLocationId ? args[0] : null;
+  const gotLocationId = /^\d{5}$/.test(trimed);
+  const locationId = gotLocationId ? trimed : null;
   // locationIdがない場合はlocationNameとして扱う
-  const locationName = !gotLocationId ? args[0] : "";
+  const locationName = !gotLocationId ? trimed : "";
   const isTomorrow = args[1] ? args[1].includes("--tomorrow") : false;
 
   return { isHelp, locationId, locationName, isTomorrow };

--- a/src/search.ts
+++ b/src/search.ts
@@ -7,7 +7,7 @@ export const byLocationName = async (
   if (locationName === "") {
     throw Error("検索文字列が指定されていません");
   }
-  const locationResponse = await zutool.search(locationName.trim());
+  const locationResponse = await zutool.search(locationName);
   const unescaped = unescape(locationResponse.result);
   return JSON.parse(unescaped);
 };


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/5877377/167528414-97b7b2b0-61d0-4d16-a63e-f719bdb63c03.png)


空白文字が含まれる場合でも地名,場所IDともに動くようにしたい。
locationNameのみtrimしていたため引数のパース時点でtrimするようにした