### PR TITLE
API GATEWAYなしでlambdaを直叩きする

### DIFF
--- a/run-zut.ts
+++ b/run-zut.ts
@@ -10,13 +10,12 @@ import * as src from "./src/index";
   const [, , ...textArray] = process.argv;
 
   const response = await src.handler({
-    "body-json": {
-      body: new URLSearchParams({
-        token: "token",
-        command: "/zut",
-        text: textArray.join(" "),
-      }).toString(),
-    },
+    body: new URLSearchParams({
+      token: "token",
+      command: "/zut",
+      text: textArray.join(" "),
+    }).toString(),
+    isBase64Encoded: false,
   });
 
   console.dir(response, { depth: null });

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -3,11 +3,13 @@ import { ParseBody, TODO } from "./Types/utils";
 import { URLSearchParams } from "url";
 
 export const getBody = (event: TODO): LambdaBody => {
-  const paramString = event["body-json"]["body"];
+  const rawBody: string = event.body;
+  const paramString = event.isBase64Encoded
+    ? Buffer.from(rawBody, "base64").toString("utf-8")
+    : rawBody;
   const body = [...new URLSearchParams(paramString).entries()].reduce(
     (obj, e) => ({ ...obj, [e[0]]: e[1] }),
     {}
   );
-
   return body;
 };

--- a/test/lambda.test.ts
+++ b/test/lambda.test.ts
@@ -1,15 +1,22 @@
 import * as lambda from "../src/lambda";
 
-test("lambdaに送信されるeventからbodyをobjectとして取り出せること", () => {
+test("isBase64Encoded=true のとき、base64デコードしてbodyをobjectとして取り出せること", () => {
+  const rawBody = "token=token&command=/zut&text=杉並";
   const event = {
-    "body-json": {
-      body: "token=token&command=/zut&text=杉並",
-    },
+    body: Buffer.from(rawBody).toString("base64"),
+    isBase64Encoded: true,
   };
+  expect(lambda.getBody(event)).toEqual(
+    expect.objectContaining({ token: "token", command: "/zut", text: "杉並" })
+  );
+});
 
-  expect({
-    token: "token",
-    command: "/zut",
-    text: "杉並",
-  }).toEqual(expect.objectContaining(lambda.getBody(event)));
+test("isBase64Encoded=false のとき、そのままbodyをobjectとして取り出せること", () => {
+  const event = {
+    body: "token=token&command=/zut&text=杉並",
+    isBase64Encoded: false,
+  };
+  expect(lambda.getBody(event)).toEqual(
+    expect.objectContaining({ token: "token", command: "/zut", text: "杉並" })
+  );
 });


### PR DESCRIPTION
API gatewayを使わずに直で lambdaを叩くようにした。
当然requestが変わる。

構造が変わったのと bodyがbase64エンコードされているのでそれに対応

```
{
    "version": "2.0",
    "routeKey": "$default",
    "rawPath": "/",
    "rawQueryString": "",
    "headers": {
        "content-length": "414",
        "x-amzn-tls-version": "TLSv1.3",
        "x-forwarded-proto": "https",
        "x-forwarded-port": "443",
        "x-forwarded-for": "54.227.108.165",
        "accept": "application/json,*/*",
        "x-amzn-tls-cipher-suite": "TLS_AES_128_GCM_SHA256",
        "x-amzn-trace-id": "Root=1-699f00f7-4e8607a42cb34af02ed9894e",
        "host": "jpvosolyv2zpfahqj5lnuoddgm0zrygo.lambda-url.ap-northeast-1.on.aws",
        "content-type": "application/x-www-form-urlencoded",
        "x-slack-request-timestamp": "1772028151",
        "x-slack-signature": "v0=8e34c47c35c8f39484f47e9932f1d415e89328adee5049dcb6dca5ccb7e469d8",
        "accept-encoding": "gzip,deflate",
        "user-agent": "Slackbot 1.0 (+https://api.slack.com/robots)"
    },
    "requestContext": {
        "accountId": "anonymous",
        "apiId": "jpvosolyv2zpfahqj5lnuoddgm0zrygo",
        "domainName": "jpvosolyv2zpfahqj5lnuoddgm0zrygo.lambda-url.ap-northeast-1.on.aws",
        "domainPrefix": "jpvosolyv2zpfahqj5lnuoddgm0zrygo",
        "http": {
            "method": "POST",
            "path": "/",
            "protocol": "HTTP/1.1",
            "sourceIp": "54.227.108.165",
            "userAgent": "Slackbot 1.0 (+https://api.slack.com/robots)"
        },
        "requestId": "78c8cc56-962e-4a96-af61-7eabbd1eaae0",
        "routeKey": "$default",
        "stage": "$default",
        "time": "25/Feb/2026:14:02:32 +0000",
        "timeEpoch": 1772028152012
    },
    "body": "dG9rZW49cmZFeGcydm5IdVdEMGt3QzJCeWFJWlZlJnRlYW1faWQ9VDAyNEc0Tk1IJnRlYW1fZG9tYWluPWNhcnRhaG9sZGluZ3MmY2hhbm5lbF9pZD1ENFNNUTNOMkMmY2hhbm5lbF9uYW1lPWRpcmVjdG1lc3NhZ2UmdXNlcl9pZD1VNFRCMkRCVTMmdXNlcl9uYW1lPXNodXpvbiZjb21tYW5kPSUyRnp1dCZ0ZXh0PTEzMTAzJmFwaV9hcHBfaWQ9QTAxRDczSDY5QTcmaXNfZW50ZXJwcmlzZV9pbnN0YWxsPWZhbHNlJnJlc3BvbnNlX3VybD1odHRwcyUzQSUyRiUyRmhvb2tzLnNsYWNrLmNvbSUyRmNvbW1hbmRzJTJGVDAyNEc0Tk1IJTJGMTA2MDg5NTg3NTkxODQlMkZRUHVlbkNpN2dTU0Z5TDZSZFpvSVpsT3gmdHJpZ2dlcl9pZD0xMDU2NTIzNDE2MDQzOS4yMTUyMTU4NzMxLmE1YTFkOWIxNzgyMDAwNjMyZDM5ZDgxNDQyNDNmNTFi",
    "isBase64Encoded": true
}
```